### PR TITLE
Adds optional openssl@1.1 compatability patch for php@5.6.

### DIFF
--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -38,9 +38,19 @@ class PhpAT56 < Formula
   depends_on "tidy-html5"
   depends_on "unixodbc"
 
+  option "with-openssl-1.1-patch", "Apply patch enabling compilation with opensssl@1.1"
+
   # PHP build system incorrectly links system libraries
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
+
+  # Applies patch enabling compilation of PHP@5.6 with homebrew openssl@1.1
+  if build.with?("openssl-1.1-patch") then
+    patch :p1 do
+      url "https://raw.githubusercontent.com/opencomputeproject/Rack-Manager/master/Contrib-Inspur/openbmc/meta-openembedded/meta-oe/recipes-devtools/php/php/0001-PHP-5.6-LibSSL-1.1-compatibility.patch"
+      sha256 "c9715b544ae249c0e76136dfadd9d282237233459694b9e75d0e3e094ab0c993"
+    end
+  end
 
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS


### PR DESCRIPTION
Patch can be enabled through use of `--with-openssl-1.1-patch` during install/reinstall. 

Formula must be installed/reinstalled from source (`--build-from-source`) for this option to have an affect.

```
$ cd /usr/local/opt/openssl/bin
$ ./openssl version
OpenSSL 1.1.1g  21 Apr 2020

$ brew install --build-from-source php@5.6 --with-openssl-1.1-patch
$ php -v
PHP 5.6.40 (cli) (built: Apr 28 2020 10:07:17)
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Xdebug v2.5.5, Copyright (c) 2002-2017, by Derick Rethans
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
```

**Fixes**
https://github.com/eXolnet/homebrew-deprecated/issues/14 https://github.com/eXolnet/homebrew-deprecated/issues/22 https://github.com/eXolnet/homebrew-deprecated/issues/23

**Probably Fixes, untested**
https://github.com/eXolnet/homebrew-deprecated/issues/17 https://github.com/eXolnet/homebrew-deprecated/issues/19